### PR TITLE
Remove mantic from old-releases list to fix "Failed getting release file"

### DIFF
--- a/freebsd/usr/local/share/debootstrap/scripts/mantic
+++ b/freebsd/usr/local/share/debootstrap/scripts/mantic
@@ -1,7 +1,7 @@
 case $ARCH in
   amd64|i386)
 	case $SUITE in
-	  gutsy|hardy|intrepid|jaunty|karmic|lucid|lunar|mantic|maverick|natty|oneiric|precise|quantal|raring|saucy|utopic|vivid|wily|yakkety|zesty)
+	  gutsy|hardy|intrepid|jaunty|karmic|lucid|lunar|maverick|natty|oneiric|precise|quantal|raring|saucy|utopic|vivid|wily|yakkety|zesty)
 	default_mirror http://old-releases.ubuntu.com/ubuntu
 	  ;;
 	  *)


### PR DESCRIPTION
This removes `mantic` from the "old-release" list so that the script will use `http://archive.ubuntu.com/ubuntu` as a mirror site instead of `http://old-releases.ubuntu.com/ubuntu`.  Fixes #1.